### PR TITLE
Swapped some instances of "Hi" for "Hello"

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,20 +12,20 @@ and answer your message.
 ## Chat Etiquette
 
 ```text
-2010-07-19 12:32:12 you: Hi
-2010-07-19 12:32:15 co-worker: Hello.
+2010-07-19 12:32:12 you: Hello
+2010-07-19 12:32:15 co-worker: Hi.
 # CO-WORKER WAITS WHILE YOU PHRASE YOUR QUESTION
 2010-07-19 12:34:01 you: I'm working on [something] and I'm trying to do [etc...]
 2010-07-19 12:35:21 co-worker: Oh, that's [answer...]
 ```
 
-It's as if you called someone on the phone and said "Hi!" and then put them on
+It's as if you called someone on the phone and said "Hello!" and then put them on
 hold!
 
 Please do this instead:
 
 ```text
-2010-07-19 12:32:12 you: Hi -- I'm working on [something] and I'm trying to do [etc...]
+2010-07-19 12:32:12 you: Hello -- I'm working on [something] and I'm trying to do [etc...]
 2010-07-19 12:33:32 co-worker: [answers question]
 ```
 


### PR DESCRIPTION
To make it clear that it's "you" that is breaching the etiquette, not the co-worker, I have swapped the initial greetings so it's "you" that says "hello", tying it back to the name of the article. I know that the point is not about "hello" vs "hi". But first time reading the page this momentarily confused me and distracted me from the point.

I have changed a few more "Hi"s to "Hello"s for consistency but allowed the interchangeability of "Hello" and "Hi" to come through by the end of the article, so the reader is not left with the impression that "Hello" vs "Hi" is the point.